### PR TITLE
remove description from blog posts

### DIFF
--- a/content/blog/2022-08-29-dev-meeting.md
+++ b/content/blog/2022-08-29-dev-meeting.md
@@ -1,6 +1,5 @@
 +++
-title = 'Dev meeting'
-description = 'The meeting took place on 04 September 2022, at 2:00 PM UTC via Google Meet, with team members from different time zones joining to discuss key aspects of the Pactus project.'
+title = 'Dev meeting - August 2022'
 author = 'Pactus Team'
 date = 2022-08-29T00:00:00+00:00
 draft = false
@@ -11,29 +10,48 @@ image = "/images/pactus-blog-post-default.jpg"
 
 ## Meeting Summary
 
-The meeting took place on 04 September 2022, at 2:00 PM UTC via Google Meet,
+The meeting took place on 29 August 2022, at 2:00 PM UTC via Google Meet,
 with team members from different time zones joining to discuss key aspects of the Pactus project.
 
-### NanoMsg instead of ZeroMQ
+### Project renamed to Pactus
 
-During the meeting, Joseph suggested using Nanomsg instead of ZeroMQ because building ZeroMQ is not easy,
-especially in Windows. Additionally, we can use the pure Go implementation of Nanomsg.
+During the last meeting, the team conducted an online survey to rename the project.
+A total of 31 responses were received, and the following names were suggested:
 
-The format of block events was defined as follows:
+| Name       | Votes |
+| ---------- | ----- |
+| Sirius     | 11    |
+| Pactus     | 10    |
+| Nova       | 7     |
+| Texo       | 6     |
+| Zemus      | 6     |
+| Helios     | 6     |
+| Tutti      | 5     |
+| Haki       | 5     |
+| Aegeus     | 4     |
+| Virgo      | 4     |
+| Zentora    | 3     |
+| Zinova     | 3     |
+| Xerxes     | 2     |
+| Ledgeria   | 2     |
+| Solidus    | 2     |
+| Welt       | 2     |
+| Ventura    | 2     |
+| Zebra      | 2     |
+| Miranet    | 2     |
+| Monetha    | 2     |
+| FutureHub  | 1     |
+| Muonet     | 1     |
+| Mentha     | 1     |
+| Hypatios   | 0     |
+| Chaintopia | 0     |
+| Sycee      | 0     |
+| Lepus      | 0     |
 
-```text
-<event_id: 1 byte><event_data: variant><height: 4 bytes><seq_num: 4 bytes>
-```
+After reviewing the responses, the team chose "Pactus" as the new name for the project. 🎉
+The project will be moved to "pactus-project/pactus," and the team plans to announce it on social media.
 
-As a consequence of this, smart contracts events can be defined more easily and
-Infura-like services become simple, as we can just replay the events.
+### Discussion on GUI
 
-### Reviewing a Pull Request
-
-Nagaraj's [pull request](https://github.com/pactus-project/pactus/pull/355) reviewed.
-
-### Renaming project
-
-The team discussed renaming (rebranding) the project and decided to create an online survey to
-gather suggestions for a new name.
-Everyone is encouraged to participate in the survey and suggest new names for the project.
+In terms of the GUI, Joseph suggested using Flutter, and the team agreed.
+To interact with the wallet, gRPC APIs will be provided, and the GUI will use these APIs.

--- a/content/blog/2022-09-04-dev-meeting.md
+++ b/content/blog/2022-09-04-dev-meeting.md
@@ -1,6 +1,5 @@
 +++
-title = 'Dev meeting'
-description = 'The meeting took place on 29 August 2022, at 2:00 PM UTC via Google Meet, with team members from different time zones joining to discuss key aspects of the Pactus project.'
+title = 'Dev meeting - September 2022'
 author = 'Pactus Team'
 date = 2022-09-04T00:00:00+00:00
 draft = false
@@ -11,48 +10,29 @@ image = "/images/pactus-blog-post-default.jpg"
 
 ## Meeting Summary
 
-The meeting took place on 29 August 2022, at 2:00 PM UTC via Google Meet,
+The meeting took place on 04 September 2022, at 2:00 PM UTC via Google Meet,
 with team members from different time zones joining to discuss key aspects of the Pactus project.
 
-### Project renamed to Pactus
+### NanoMsg instead of ZeroMQ
 
-During the last meeting, the team conducted an online survey to rename the project.
-A total of 31 responses were received, and the following names were suggested:
+During the meeting, Joseph suggested using Nanomsg instead of ZeroMQ because building ZeroMQ is not easy,
+especially in Windows. Additionally, we can use the pure Go implementation of Nanomsg.
 
-| Name       | Votes |
-| ---------- | ----- |
-| Sirius     | 11    |
-| Pactus     | 10    |
-| Nova       | 7     |
-| Texo       | 6     |
-| Zemus      | 6     |
-| Helios     | 6     |
-| Tutti      | 5     |
-| Haki       | 5     |
-| Aegeus     | 4     |
-| Virgo      | 4     |
-| Zentora    | 3     |
-| Zinova     | 3     |
-| Xerxes     | 2     |
-| Ledgeria   | 2     |
-| Solidus    | 2     |
-| Welt       | 2     |
-| Ventura    | 2     |
-| Zebra      | 2     |
-| Miranet    | 2     |
-| Monetha    | 2     |
-| FutureHub  | 1     |
-| Muonet     | 1     |
-| Mentha     | 1     |
-| Hypatios   | 0     |
-| Chaintopia | 0     |
-| Sycee      | 0     |
-| Lepus      | 0     |
+The format of block events was defined as follows:
 
-After reviewing the responses, the team chose "Pactus" as the new name for the project. 🎉
-The project will be moved to "pactus-project/pactus," and the team plans to announce it on social media.
+```text
+<event_id: 1 byte><event_data: variant><height: 4 bytes><seq_num: 4 bytes>
+```
 
-### Discussion on GUI
+As a consequence of this, smart contracts events can be defined more easily and
+Infura-like services become simple, as we can just replay the events.
 
-In terms of the GUI, Joseph suggested using Flutter, and the team agreed.
-To interact with the wallet, gRPC APIs will be provided, and the GUI will use these APIs.
+### Reviewing a Pull Request
+
+Nagaraj's [pull request](https://github.com/pactus-project/pactus/pull/355) reviewed.
+
+### Renaming project
+
+The team discussed renaming (rebranding) the project and decided to create an online survey to
+gather suggestions for a new name.
+Everyone is encouraged to participate in the survey and suggest new names for the project.

--- a/content/blog/2022-09-18-dev-meeting.md
+++ b/content/blog/2022-09-18-dev-meeting.md
@@ -1,6 +1,5 @@
 +++
-title = 'Dev meeting'
-description = 'The meeting took place on 18 September 2022, at 2:00 PM UTC via Google Meet, with team members from different time zones joining to discuss key aspects of the Pactus project.'
+title = 'Dev meeting - September 2022'
 author = 'Pactus Team'
 date = 2022-09-18T00:00:00+00:00
 draft = false

--- a/content/blog/2022-09-20-release-0-9-0.md
+++ b/content/blog/2022-09-20-release-0-9-0.md
@@ -1,6 +1,5 @@
 +++
 title = 'Pactus 0.9.0 Released'
-description = 'Pactus Blockchain has released Version 0.9.0, available for download. This release includes the Pactus GUI for both beginners and experienced users, the Pactus Daemon CLI for experienced users, the Pactus Shell for node interaction, and the Pactus Wallet for managing transactions without syncing the entire blockchain.'
 author = 'Pactus Team'
 date = 2022-09-20T00:00:00+00:00
 draft = false

--- a/content/blog/2022-09-24-testnet-0-launched.md
+++ b/content/blog/2022-09-24-testnet-0-launched.md
@@ -1,6 +1,5 @@
 +++
 title = 'Testnet-0 launch announcement'
-description = 'The Pactus blockchain Testnet-0 is now available for participation.'
 author = 'Pactus Team'
 date = 2022-09-24T00:00:00+00:00
 draft = false
@@ -8,6 +7,8 @@ tags = ['announcement', 'pactus', 'testnet']
 slug = 'testnet-0-launched'
 image = "/images/pactus-blog-post-default.jpg"
 +++
+
+## Overview
 
 The Pactus blockchain Testnet-0 is now accessible.
 To participate, simply [download](/download) the Pactus application version 0.9.0 and

--- a/content/blog/2022-10-30-dev-meeting.md
+++ b/content/blog/2022-10-30-dev-meeting.md
@@ -1,6 +1,5 @@
 +++
-title = 'Dev meeting'
-description = 'The meeting took place on 30 October 2022, at 2:00 PM UTC via Google Meet, with team members from different time zones joining to discuss key aspects of the Pactus project.'
+title = 'Dev meeting - October 2022'
 author = 'Pactus Team'
 date = 2022-10-30T00:00:00+00:00
 draft = false

--- a/content/blog/2022-11-24-release-0-9-1.md
+++ b/content/blog/2022-11-24-release-0-9-1.md
@@ -1,6 +1,5 @@
 +++
 title = 'Pactus 0.9.1 Released'
-description = 'Pactus Blockchain has released Version 0.9.1, available for download. This release includes the Pactus GUI for both beginners and experienced users, the Pactus Daemon CLI for experienced users, the Pactus Shell for node interaction, and the Pactus Wallet for managing transactions without syncing the entire blockchain.'
 author = 'Pactus Team'
 date = 2022-11-24T00:00:00+00:00
 draft = false

--- a/content/blog/2023-03-31-what-is-testnet.md
+++ b/content/blog/2023-03-31-what-is-testnet.md
@@ -1,6 +1,5 @@
 +++
 title = 'What is a Testnet?'
-description = 'If you have ever wondered what Testnet is and how it is different from Mainnet, read this article to the end to find out!'
 author = 'Pactus Team'
 date = 2023-03-31T00:00:00+00:00
 draft = false

--- a/content/blog/2023-04-21-testnet-0-concluded.md
+++ b/content/blog/2023-04-21-testnet-0-concluded.md
@@ -1,6 +1,5 @@
 +++
 title = 'Story of Testnet-0'
-description = 'The Pactus blockchain Testnet-0 is now available for participation.'
 author = 'Pactus Team'
 date = 2023-04-21T00:00:00+00:00
 draft = false
@@ -15,11 +14,11 @@ Testnet is a testing environment where developers and users can try out the func
 without putting real assets or data at risk.
 It helps to ensure that the final product is reliable and secure for users to use.
 If you like to read more about the Testnet you can check out our post on
-"[What is Testnet?](/2023/03/01/what-is-testnet)".
+"[What is Testnet?](/2023/03/31/what-is-testnet/)".
 
 ## Summary of Testnet-0
 
-In September 2022, we launched [Testnet-0](/2022/09/24/testnet-0-launched).
+In September 2022, we launched [Testnet-0](/2022/09/24/testnet-0-launched/).
 The purpose of this Testnet was to
 check the [consensus protocol](https://docs.pactus.org/protocol/consensus/protocol/),
 test different [transaction](https://docs.pactus.org/protocol/transaction/format/) types,

--- a/content/blog/2023-05-08-release-0-10-0.md
+++ b/content/blog/2023-05-08-release-0-10-0.md
@@ -1,6 +1,5 @@
 +++
 title = 'Pactus 0.10.0 Released'
-description = 'Pactus Blockchain has released Version 0.10.0, available for download. This release includes the Pactus GUI for both beginners and experienced users, the Pactus Daemon CLI for experienced users, the Pactus Shell for node interaction, and the Pactus Wallet for managing transactions without syncing the entire blockchain.'
 author = 'Pactus Team'
 date = 2023-05-08T00:00:00+00:00
 draft = false

--- a/content/blog/2023-05-09-testnet-1-launched.md
+++ b/content/blog/2023-05-09-testnet-1-launched.md
@@ -1,6 +1,5 @@
 +++
 title = 'Testnet-1 launch announcement'
-description = 'The Pactus blockchain Testnet-1 is now available for participation.'
 author = 'Pactus Team'
 date = 2023-05-09T00:00:00+00:00
 draft = false

--- a/content/blog/2023-05-29-release-0-11-0.md
+++ b/content/blog/2023-05-29-release-0-11-0.md
@@ -1,6 +1,5 @@
 +++
 title = 'Pactus 0.11.0 Released'
-description = 'Pactus Blockchain has released Version 0.11.0, available for download. This release includes the Pactus GUI for both beginners and experienced users, the Pactus Daemon CLI for experienced users, the Pactus Shell for node interaction, and the Pactus Wallet for managing transactions without syncing the entire blockchain.'
 author = 'Pactus Team'
 date = 2023-05-29T00:00:00+00:00
 draft = false

--- a/content/blog/2023-06-19-release-0-12-0.md
+++ b/content/blog/2023-06-19-release-0-12-0.md
@@ -1,6 +1,5 @@
 +++
 title = 'Pactus 0.12.0 Released'
-description = 'Pactus Blockchain has released Version 0.12.0, available for download. This release includes the Pactus GUI for both beginners and experienced users, the Pactus Daemon CLI for experienced users, the Pactus Shell for node interaction, and the Pactus Wallet for managing transactions without syncing the entire blockchain.'
 author = 'Pactus Team'
 date = 2023-06-19T00:00:00+00:00
 draft = false

--- a/content/blog/2023-07-01-release-0-13-0.md
+++ b/content/blog/2023-07-01-release-0-13-0.md
@@ -1,6 +1,5 @@
 +++
 title = 'Pactus 0.13.0 Released'
-description = 'Pactus Blockchain has released Version 0.13.0, available for download. This release includes the Pactus GUI for both beginners and experienced users, the Pactus Daemon CLI for experienced users, the Pactus Shell for node interaction, and the Pactus Wallet for managing transactions without syncing the entire blockchain.'
 author = 'Pactus Team'
 date = 2023-07-01T00:00:00+00:00
 draft = false

--- a/content/blog/2023-07-05-testnet-500-validators.md
+++ b/content/blog/2023-07-05-testnet-500-validators.md
@@ -1,6 +1,5 @@
 +++
 title = '500 validators joined Testnet'
-description = 'For a Proof of Stake blockchain, validators are important for maintaining the network integrity and security. They are similar to miners in Proof of Work blockchains like Bitcoin.'
 author = 'Pactus Team'
 date = 2023-07-05T00:00:00+00:00
 draft = false
@@ -13,7 +12,7 @@ For a [Proof of Stake](https://docs.pactus.org/protocol/consensus/proof-of-stake
 maintaining the network's integrity and security. They are similar to miners in Proof of Work blockchains like Bitcoin.
 
 Pactus as a real Proof of Stake blockchain, has achieved a significant milestone.
-More than 500 validators joined the [Testnet](/2023/05/09/testnet-1-launched)
+More than 500 validators joined the [Testnet](/2023/05/09/testnet-1-launched/)
 in less than 2 months.
 This accomplishment proves that Pactus is reliable, resilient, and trustworthy. More importantly, it sets new standards
 in the blockchain world. In fact, **the Pactus Testnet is even more decentralized than some well-known blockchains.**

--- a/content/blog/2023-07-09-dev-meeting.md
+++ b/content/blog/2023-07-09-dev-meeting.md
@@ -1,6 +1,5 @@
 +++
-title = 'Dev meeting'
-description = 'The meeting took place on 09 July 2023, at 2:00 PM UTC via Google Meet, with team members from different time zones joining to discuss key aspects of the Pactus project.'
+title = 'Dev meeting - July 2023'
 author = 'Pactus Team'
 date = 2023-07-09T00:00:00+00:00
 draft = false

--- a/content/blog/2023-08-01-testnet-1-concluded.md
+++ b/content/blog/2023-08-01-testnet-1-concluded.md
@@ -1,6 +1,5 @@
 +++
 title = 'Story of Testnet-1'
-description = 'Testnet is a testing environment where developers and users can try out the functionality of a blockchain project, without putting real assets or data at risk.'
 author = 'Pactus Team'
 date = 2023-08-01T00:00:00+00:00
 draft = false

--- a/content/blog/2023-08-22-dev-report.md
+++ b/content/blog/2023-08-22-dev-report.md
@@ -1,6 +1,5 @@
 +++
 title = 'Dev report'
-description = 'there is several activities in Pactus github this month, here is a clear report and explain of activities.'
 author = 'Pactus Team'
 date = 2023-08-22T00:00:00+00:00
 draft = false

--- a/content/blog/2023-09-04-introduction-to-pips.md
+++ b/content/blog/2023-09-04-introduction-to-pips.md
@@ -1,6 +1,5 @@
 +++
 title = 'Introduction to PIPs'
-description = 'In our commitment to transparency and innovation, were excited to introduce a major step in Pactus journey, the Pactus Improvement Proposals, or PIPs.'
 author = 'Pactus Team'
 date = 2023-09-04T00:00:00+00:00
 draft = false

--- a/content/blog/2023-09-24-dev-report-pre-testnet-2.md
+++ b/content/blog/2023-09-24-dev-report-pre-testnet-2.md
@@ -1,6 +1,5 @@
 +++
 title = 'Dev Report pre-testnet2'
-description = 'there is several activities in Pactus github in September month, here is a clear report and explain of activities.'
 author = 'Pactus Team'
 date = 2023-09-24T00:00:00+00:00
 draft = false

--- a/content/blog/2023-09-28-how-sspos-works-in-simple-word.md
+++ b/content/blog/2023-09-28-how-sspos-works-in-simple-word.md
@@ -1,6 +1,5 @@
 +++
 title = 'How SSPoS (Solid State Proof of Stake) works in simple word'
-description = 'In all Blockchain protocols, there is a concept called a consensus mechanism.'
 author = 'Pactus Team'
 date = 2023-09-28T00:00:00+00:00
 draft = false

--- a/content/blog/2023-10-15-release-0-15-0.md
+++ b/content/blog/2023-10-15-release-0-15-0.md
@@ -1,6 +1,5 @@
 +++
 title = 'Pactus 0.15.0 Released'
-description = 'Pactus Blockchain has released Version 0.15.0, available for download. This release includes the Pactus GUI for both beginners and experienced users, the Pactus Daemon CLI for experienced users, the Pactus Shell for node interaction, and the Pactus Wallet for managing transactions without syncing the entire blockchain.'
 author = 'Pactus Team'
 date = 2023-10-15T00:00:00+00:00
 draft = false

--- a/content/blog/2023-10-15-testnet-2-launched.md
+++ b/content/blog/2023-10-15-testnet-2-launched.md
@@ -1,6 +1,5 @@
 +++
 title = 'Testnet-2 launch announcement'
-description = 'Exciting news for the Pactus Community: Testnet-2 is has launched! The journey through Testnet-1 brought success and invaluable experiences, with over 500 validators joining the network.'
 author = 'Pactus Team'
 date = 2023-10-15T00:00:00+00:00
 draft = false

--- a/content/blog/2023-10-29-release-0-16-0.md
+++ b/content/blog/2023-10-29-release-0-16-0.md
@@ -1,6 +1,5 @@
 +++
 title = 'Pactus 0.16.0 Released'
-description = 'Pactus Blockchain has released Version 0.16.0, available for download. This release includes the Pactus GUI for both beginners and experienced users, the Pactus Daemon CLI for experienced users, the Pactus Shell for node interaction, and the Pactus Wallet for managing transactions without syncing the entire blockchain.'
 author = 'Pactus Team'
 date = 2023-10-29T00:00:00+00:00
 draft = false

--- a/content/blog/2023-11-12-release-0-17-0.md
+++ b/content/blog/2023-11-12-release-0-17-0.md
@@ -1,6 +1,5 @@
 +++
 title = 'Pactus 0.17.0 Released'
-description = 'Pactus Blockchain has released Version 0.17.0, available for download. This release includes the Pactus GUI for both beginners and experienced users, the Pactus Daemon CLI for experienced users, the Pactus Shell for node interaction, and the Pactus Wallet for managing transactions without syncing the entire blockchain.'
 author = 'Pactus Team'
 date = 2023-11-12T00:00:00+00:00
 draft = false

--- a/content/blog/2023-12-12-release-0-18-0.md
+++ b/content/blog/2023-12-12-release-0-18-0.md
@@ -1,6 +1,5 @@
 +++
 title = 'Pactus 0.18.0 Released'
-description = 'Pactus Blockchain has released Version 0.18.0, available for download. This release includes the Pactus GUI for both beginners and experienced users, the Pactus Daemon CLI for experienced users, the Pactus Shell for node interaction, and the Pactus Wallet for managing transactions without syncing the entire blockchain.'
 author = 'Pactus Team'
 date = 2023-12-12T00:00:00+00:00
 draft = false

--- a/content/blog/2024-01-04-release-0-19-0.md
+++ b/content/blog/2024-01-04-release-0-19-0.md
@@ -1,6 +1,5 @@
 +++
 title = 'Pactus 0.19.0 Released'
-description = 'Pactus Blockchain has released Version 0.19.0, available for download. This release includes the Pactus GUI for both beginners and experienced users, the Pactus Daemon CLI for experienced users, the Pactus Shell for node interaction, and the Pactus Wallet for managing transactions without syncing the entire blockchain.'
 author = 'Pactus Team'
 date = 2024-01-04T00:00:00+00:00
 draft = false

--- a/content/blog/2024-01-08-mainnet-announcement.md
+++ b/content/blog/2024-01-08-mainnet-announcement.md
@@ -1,6 +1,5 @@
 +++
 title = 'Mainnet announcement'
-description = 'The much-awaited Mainnet Launch of The Pactus Blockchain is finally here!'
 author = 'Pactus Team'
 date = 2024-01-08T00:00:00+00:00
 draft = false
@@ -8,6 +7,8 @@ tags = ['announcement', 'mainnet', 'pactus', 'blockchain']
 slug = 'mainnet-announcement'
 image = "/images/pactus-blog-post-default.jpg"
 +++
+
+## Overview
 
 The much-awaited Mainnet Launch of The Pactus Blockchain is finally here!
 On January 24, 2024, at 20:24:00 UTC, the first block, known as the [Genesis block](https://docs.pactus.org/protocol/blockchain/genesis/),

--- a/content/blog/2024-01-11-release-0-20-0.md
+++ b/content/blog/2024-01-11-release-0-20-0.md
@@ -1,6 +1,5 @@
 +++
 title = 'Pactus 0.20.0 Released'
-description = 'Pactus Blockchain has released Version 0.20.0, available for download. This release includes the Pactus GUI for both beginners and experienced users, the Pactus Daemon CLI for experienced users, the Pactus Shell for node interaction, and the Pactus Wallet for managing transactions without syncing the entire blockchain.'
 author = 'Pactus Team'
 date = 2024-01-11T00:00:00+00:00
 draft = false

--- a/content/blog/2024-01-22-testnet-2-concluded.md
+++ b/content/blog/2024-01-22-testnet-2-concluded.md
@@ -1,6 +1,5 @@
 +++
 title = 'Story of Testnet-2'
-description = 'Testnet is a testing environment where developers and users can try out the functionality of a blockchain project, without putting real assets or data at risk.'
 author = 'Pactus Team'
 date = 2024-01-22T00:00:00+00:00
 draft = false

--- a/content/blog/2024-01-24-mainnet-launched.md
+++ b/content/blog/2024-01-24-mainnet-launched.md
@@ -1,6 +1,5 @@
 +++
 title = 'Mainnet launched 🚀'
-description = 'Pactus Mainnet started creating the first block on 24 January 2024 at 20:24:10 UTC time. Pactus Mainnet is the result of years of hard work, research, and innovation.'
 author = 'Pactus Team'
 date = 2024-01-24T00:00:00+00:00
 draft = false

--- a/content/blog/2024-01-31-release-1-0-0.md
+++ b/content/blog/2024-01-31-release-1-0-0.md
@@ -1,6 +1,5 @@
 +++
 title = 'Pactus 1.0.0 (Beijing) Released'
-description = 'Pactus Blockchain has released Version 1.0.0 (Beijing), available for download. This release includes the Pactus GUI for both beginners and experienced users, the Pactus Daemon CLI for experienced users, the Pactus Shell for node interaction, and the Pactus Wallet for managing transactions without syncing the entire blockchain.'
 author = 'Pactus Team'
 date = 2024-01-31T00:00:00+00:00
 draft = false

--- a/content/blog/2024-02-10-release-1-0-1.md
+++ b/content/blog/2024-02-10-release-1-0-1.md
@@ -1,6 +1,5 @@
 +++
 title = 'Pactus 1.0.1 (Beijing) Released'
-description = 'Pactus Blockchain has released Version 1.0.1 (Beijing), available for download. This release includes the Pactus GUI for both beginners and experienced users, the Pactus Daemon CLI for experienced users, the Pactus Shell for node interaction, and the Pactus Wallet for managing transactions without syncing the entire blockchain.'
 author = 'Pactus Team'
 date = 2024-02-10T00:00:00+00:00
 draft = false

--- a/content/blog/2024-02-18-release-1-0-2.md
+++ b/content/blog/2024-02-18-release-1-0-2.md
@@ -1,6 +1,5 @@
 +++
 title = 'Pactus 1.0.2 (Istanbul) Released'
-description = 'Pactus Blockchain has released Version 1.0.2 (Istanbul), available for download. This release includes the Pactus GUI for both beginners and experienced users, the Pactus Daemon CLI for experienced users, the Pactus Shell for node interaction, and the Pactus Wallet for managing transactions without syncing the entire blockchain.'
 author = 'Pactus Team'
 date = 2024-02-18T00:00:00+00:00
 draft = false

--- a/content/blog/2024-03-16-testnet-phoenix-launched.md
+++ b/content/blog/2024-03-16-testnet-phoenix-launched.md
@@ -1,6 +1,5 @@
 +++
 title = 'Pactus Permanent Phoenix Testnet Launched'
-description = 'Pactus Permanent Phoenix Testnet Launched.'
 author = 'Pactus Team'
 date = 2024-03-16T00:00:00+00:00
 draft = false
@@ -8,6 +7,8 @@ tags = ['announcement', 'testnet', 'pactus']
 slug = 'testnet-phoenix-launched'
 image = "/images/pactus-public-testnet-phoenix.png"
 +++
+
+## Overview
 
 The public and permanent Phoenix [Testnet](/2023/03/01/what-is-testnet)
 for the Pactus blockchain has been launched.

--- a/content/blog/2024-04-18-release-1-1-1.md
+++ b/content/blog/2024-04-18-release-1-1-1.md
@@ -1,6 +1,5 @@
 +++
 title = 'Pactus 1.1.1 (Jakarta) Released'
-description = 'Pactus Blockchain has released Version 1.1.1 (Jakarta), available for download. This release includes the Pactus GUI for both beginners and experienced users, the Pactus Daemon CLI for experienced users, the Pactus Shell for node interaction, and the Pactus Wallet for managing transactions without syncing the entire blockchain.'
 author = 'Pactus Team'
 date = 2024-04-18T00:00:00+00:00
 draft = false

--- a/content/blog/2024-04-25-release-1-1-3.md
+++ b/content/blog/2024-04-25-release-1-1-3.md
@@ -1,6 +1,5 @@
 +++
 title = 'Pactus 1.1.3 (Kuala Lumpur) Released'
-description = 'Pactus Blockchain has released Version 1.1.3 (Kuala Lumpur), available for download. This release includes the Pactus GUI for both beginners and experienced users, the Pactus Daemon CLI for experienced users, the Pactus Shell for node interaction, and the Pactus Wallet for managing transactions without syncing the entire blockchain.'
 author = 'Pactus Team'
 date = 2024-04-25T00:00:00+00:00
 draft = false

--- a/content/blog/2024-05-07-release-1-1-4.md
+++ b/content/blog/2024-05-07-release-1-1-4.md
@@ -1,6 +1,5 @@
 +++
 title = 'Pactus 1.1.4 (London) Released'
-description = 'Pactus Blockchain has released Version 1.1.4 (London), available for download. This release includes the Pactus GUI for both beginners and experienced users, the Pactus Daemon CLI for experienced users, the Pactus Shell for node interaction, and the Pactus Wallet for managing transactions without syncing the entire blockchain.'
 author = 'Pactus Team'
 date = 2024-05-07T00:00:00+00:00
 draft = false

--- a/content/blog/2024-06-02-release-1-1-8.md
+++ b/content/blog/2024-06-02-release-1-1-8.md
@@ -1,6 +1,5 @@
 +++
 title = 'Pactus 1.1.8 (Budapest) Released'
-description = 'Pactus Blockchain has released Version 1.1.8 (Budapest), available for download. This release includes the Pactus GUI for both beginners and experienced users, the Pactus Daemon CLI for experienced users, the Pactus Shell for node interaction, and the Pactus Wallet for managing transactions without syncing the entire blockchain.'
 author = 'Pactus Team'
 date = 2024-06-02T00:00:00+00:00
 draft = false

--- a/content/blog/2024-06-20-release-1-2-0.md
+++ b/content/blog/2024-06-20-release-1-2-0.md
@@ -1,6 +1,5 @@
 +++
 title = 'Pactus 1.2.0 (Sydney) Released'
-description = 'Pactus Blockchain has released Version 1.2.0 (Sydney), available for download. This release includes the Pactus GUI for both beginners and experienced users, the Pactus Daemon CLI for experienced users, the Pactus Shell for node interaction, and the Pactus Wallet for managing transactions without syncing the entire blockchain.'
 author = 'Pactus Team'
 date = 2024-06-20T00:00:00+00:00
 draft = false

--- a/content/blog/2024-06-27-release-1-3-0.md
+++ b/content/blog/2024-06-27-release-1-3-0.md
@@ -1,6 +1,5 @@
 +++
 title = 'Pactus 1.3.0 (Warsaw) Released'
-description = 'Pactus Blockchain has released Version 1.3.0 (Warsaw), available for download. This release includes the Pactus GUI for both beginners and experienced users, the Pactus Daemon CLI for experienced users, the Pactus Shell for node interaction, and the Pactus Wallet for managing transactions without syncing the entire blockchain.'
 author = 'Pactus Team'
 date = 2024-06-27T00:00:00+00:00
 draft = false

--- a/content/blog/2024-08-01-release-1-4-0.md
+++ b/content/blog/2024-08-01-release-1-4-0.md
@@ -1,6 +1,5 @@
 +++
 title = 'Pactus 1.4.0 (Amsterdam) Released'
-description = 'Pactus Blockchain has released Version 1.4.0 (Amsterdam), available for download. This release includes the Pactus GUI for both beginners and experienced users, the Pactus Daemon CLI for experienced users, the Pactus Shell for node interaction, and the Pactus Wallet for managing transactions without syncing the entire blockchain.'
 author = 'Pactus Team'
 date = 2024-08-01T00:00:00+00:00
 draft = false


### PR DESCRIPTION
This PR removes descriptions from the blog posts. 
PR #6 made descriptions optional, allowing us to simplify blog posts.