### PR TITLE
Get release version from config

### DIFF
--- a/content/download.md
+++ b/content/download.md
@@ -40,7 +40,7 @@ This script can download the archived file, verify it, and extract it for you.
 To use it, simply run the following command in your terminal:
 
 <pre>
-curl --proto '=https' --tlsv1.2 -sSL https://github.com/pactus-project/pactus/releases/download/<span class="latest-version">---</span>/pactus_downloader.sh | sh
+curl --proto '=https' --tlsv1.2 -sSL <span class="latest-version">---</span>/pactus_downloader.sh | sh
 </pre>
 
 ---

--- a/content/download.md
+++ b/content/download.md
@@ -40,7 +40,7 @@ This script can download the archived file, verify it, and extract it for you.
 To use it, simply run the following command in your terminal:
 
 <pre>
-curl --proto '=https' --tlsv1.2 -sSL <span class="latest-version">---</span>/pactus_downloader.sh | sh
+curl --proto '=https' --tlsv1.2 -sSL <span class="release-tag-link">---</span>/pactus_downloader.sh | sh
 </pre>
 
 ---

--- a/hugo.toml
+++ b/hugo.toml
@@ -7,7 +7,7 @@ canonifyURLs = true
   blog = "/:year/:month/:day/:title/"
 
 [params]
-  latestVersion = "1.4.0"
+  releaseTag = "v1.5.0"
   mainCSS = "css/main.css"
   subtitle = "Building decentralized future together!"
   [params.contact]

--- a/layouts/shortcodes/download_links.html
+++ b/layouts/shortcodes/download_links.html
@@ -72,7 +72,7 @@
   async function fetchLatestRelease() {
     let cachedRelease = localStorage.getItem("latestRelease");
     const response = await fetch(
-      "https://api.github.com/repos/pactus-project/pactus/releases/latest",
+      "https://api.github.com/repos/pactus-project/pactus/releases/tags/{{.Site.Params.releaseTag}}",
     );
     if (!response.ok) {
       return JSON.parse(cachedRelease) || {};
@@ -184,7 +184,7 @@
       const latestVersionElements =
         document.getElementsByClassName("latest-version");
       for (let i = 0; i < latestVersionElements.length; i++) {
-        latestVersionElements[i].innerHTML = release.tag_name;
+        latestVersionElements[i].innerHTML = `https://github.com/pactus-project/pactus/releases/download/${release.tag_name}`;
       }
 
       const cliTable = createTable(release.assets, "cli");

--- a/layouts/shortcodes/download_links.html
+++ b/layouts/shortcodes/download_links.html
@@ -182,7 +182,7 @@
       const release = await fetchLatestRelease();
 
       const latestVersionElements =
-        document.getElementsByClassName("latest-version");
+        document.getElementsByClassName("release-tag-link");
       for (let i = 0; i < latestVersionElements.length; i++) {
         latestVersionElements[i].innerHTML = `https://github.com/pactus-project/pactus/releases/download/${release.tag_name}`;
       }


### PR DESCRIPTION
This PR get release tag from `hugo.yaml` config file instead of getting latest version.
Also fixes `download.md` lint